### PR TITLE
Replace deprecated lighten() in styles

### DIFF
--- a/components/HomepageUILarge/NavigationBar.vue
+++ b/components/HomepageUILarge/NavigationBar.vue
@@ -11,6 +11,7 @@
 </template>
 
 <style lang="scss">
+@use "sass:color";
 .large-navigation-bar {
   padding: 0 170px;
   z-index: 999;
@@ -42,7 +43,7 @@
     transform: translateX(-20px);
 
     &:hover {
-      background-color: lighten(#08415c, 5);
+      background-color: color.adjust(#08415c, $lightness: 5%);
     }
 
     &-wrapper {

--- a/components/HomepageUILarge/VideoDescription.vue
+++ b/components/HomepageUILarge/VideoDescription.vue
@@ -129,6 +129,7 @@ function getUIType() {
 </template>
 
 <style lang="scss">
+@use "sass:color";
 .full_content {
   z-index: 1;
   //position: absolute;
@@ -231,8 +232,8 @@ function getUIType() {
       padding: 0;
     }
     &:hover {
-      background-color: lighten(#fc8b00, 9);
-      border-color: lighten(#fc8b00, 9);
+      background-color: color.adjust(#fc8b00, $lightness: 9%);
+      border-color: color.adjust(#fc8b00, $lightness: 9%);
     }
 
     &:disabled {
@@ -268,8 +269,8 @@ function getUIType() {
     border-color: #4f8d71;
   }
   & > .video__play:hover {
-    background-color: lighten(#4f8d71, 9);
-    border-color: lighten(#4f8d71, 9);;
+    background-color: color.adjust(#4f8d71, $lightness: 9%);
+    border-color: color.adjust(#4f8d71, $lightness: 9%);
   }
 }
 
@@ -280,8 +281,8 @@ function getUIType() {
     border-color: #fc8b00;
   }
   & > .video__play:hover {
-    background-color: lighten(#fc8b00, 9);
-    border-color: lighten(#fc8b00, 9);
+    background-color: color.adjust(#fc8b00, $lightness: 9%);
+    border-color: color.adjust(#fc8b00, $lightness: 9%);
   }
 }
 
@@ -292,8 +293,8 @@ function getUIType() {
     border-color: #c73540;
   }
   & > .video__play:hover {
-    background-color: lighten(#c73540, 9);
-    border-color: lighten(#c73540, 9);
+    background-color: color.adjust(#c73540, $lightness: 9%);
+    border-color: color.adjust(#c73540, $lightness: 9%);
   }
 }
 
@@ -304,8 +305,8 @@ function getUIType() {
     border-color: #631764;
   }
   & > .video__play:hover {
-    background-color: lighten(#631764, 9);
-    border-color: lighten(#631764, 9);
+    background-color: color.adjust(#631764, $lightness: 9%);
+    border-color: color.adjust(#631764, $lightness: 9%);
   }
 }
 .award-list--mobile {

--- a/pages/watch/[id].vue
+++ b/pages/watch/[id].vue
@@ -258,6 +258,7 @@ useHead && useHead(computed(() => ({
 </template>
 
 <style lang="scss">
+@use "sass:color";
 .watch-view {
   position: relative;
   width: 100vw;
@@ -420,7 +421,7 @@ useHead && useHead(computed(() => ({
 
     &:hover {
       text-decoration: none;
-      background-color: lighten(#007dad, 7);
+      background-color: color.adjust(#007dad, $lightness: 7%);
       color: #ffffff;
     }
   }

--- a/public/css/_scaffold.scss
+++ b/public/css/_scaffold.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 *,
 *::before,
 *::after {
@@ -143,7 +144,7 @@ a {
   -webkit-text-decoration-skip: objects;
 }
 a:hover {
-  color: lighten($colors-blue, 10);
+  color: color.adjust($colors-blue, $lightness: 10%);
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## Summary
- replace deprecated `lighten()` with `color.adjust` in various styles
- load the `sass:color` module where needed

## Testing
- `npm run build`