### PR TITLE
Remove Sass deprecations

### DIFF
--- a/components/HomepageUILarge/NavigationBar.vue
+++ b/components/HomepageUILarge/NavigationBar.vue
@@ -11,6 +11,7 @@
 </template>
 
 <style lang="scss">
+@use "sass:color";
 .large-navigation-bar {
   padding: 0 170px;
   z-index: 999;
@@ -41,9 +42,9 @@
     transition: background-color 0.13s ease-in-out;
     transform: translateX(-20px);
 
-    &:hover {
-      background-color: lighten(#08415c, 5);
-    }
+      &:hover {
+        background-color: color.adjust(#08415c, $lightness: 5%);
+      }
 
     &-wrapper {
       flex: 0;

--- a/components/HomepageUILarge/VideoDescription.vue
+++ b/components/HomepageUILarge/VideoDescription.vue
@@ -129,6 +129,7 @@ function getUIType() {
 </template>
 
 <style lang="scss">
+@use "sass:color";
 .full_content {
   z-index: 1;
   //position: absolute;
@@ -230,10 +231,10 @@ function getUIType() {
       box-sizing: border-box;  
       padding: 0;
     }
-    &:hover {
-      background-color: lighten(#fc8b00, 9);
-      border-color: lighten(#fc8b00, 9);
-    }
+      &:hover {
+        background-color: color.adjust(#fc8b00, $lightness: 9%);
+        border-color: color.adjust(#fc8b00, $lightness: 9%);
+      }
 
     &:disabled {
       opacity: 0.33;
@@ -268,8 +269,8 @@ function getUIType() {
     border-color: #4f8d71;
   }
   & > .video__play:hover {
-    background-color: lighten(#4f8d71, 9);
-    border-color: lighten(#4f8d71, 9);;
+    background-color: color.adjust(#4f8d71, $lightness: 9%);
+    border-color: color.adjust(#4f8d71, $lightness: 9%);
   }
 }
 
@@ -280,8 +281,8 @@ function getUIType() {
     border-color: #fc8b00;
   }
   & > .video__play:hover {
-    background-color: lighten(#fc8b00, 9);
-    border-color: lighten(#fc8b00, 9);
+    background-color: color.adjust(#fc8b00, $lightness: 9%);
+    border-color: color.adjust(#fc8b00, $lightness: 9%);
   }
 }
 
@@ -292,8 +293,8 @@ function getUIType() {
     border-color: #c73540;
   }
   & > .video__play:hover {
-    background-color: lighten(#c73540, 9);
-    border-color: lighten(#c73540, 9);
+    background-color: color.adjust(#c73540, $lightness: 9%);
+    border-color: color.adjust(#c73540, $lightness: 9%);
   }
 }
 
@@ -304,8 +305,8 @@ function getUIType() {
     border-color: #631764;
   }
   & > .video__play:hover {
-    background-color: lighten(#631764, 9);
-    border-color: lighten(#631764, 9);
+    background-color: color.adjust(#631764, $lightness: 9%);
+    border-color: color.adjust(#631764, $lightness: 9%);
   }
 }
 .award-list--mobile {

--- a/pages/watch/[id].vue
+++ b/pages/watch/[id].vue
@@ -240,6 +240,7 @@ useHead && useHead(computed(() => ({
 </template>
 
 <style lang="scss">
+@use "sass:color";
 .watch-view {
   position: relative;
   width: 100vw;
@@ -377,16 +378,6 @@ useHead && useHead(computed(() => ({
   }
 
   &__tweet-this {
-    &-wrapper {
-      text-align: center;
-      transform: translateY(50%);
-
-      @include media-breakpoint-small {
-        transform: none;
-        padding: 16px 0 32px 0;
-      }
-    }
-
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -402,8 +393,18 @@ useHead && useHead(computed(() => ({
 
     &:hover {
       text-decoration: none;
-      background-color: lighten(#007dad, 7);
+      background-color: color.adjust(#007dad, $lightness: 7%);
       color: #ffffff;
+    }
+
+    &-wrapper {
+      text-align: center;
+      transform: translateY(50%);
+
+      @include media-breakpoint-small {
+        transform: none;
+        padding: 16px 0 32px 0;
+      }
     }
   }
 

--- a/public/css/_scaffold.scss
+++ b/public/css/_scaffold.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 *,
 *::before,
 *::after {
@@ -143,7 +144,7 @@ a {
   -webkit-text-decoration-skip: objects;
 }
 a:hover {
-  color: lighten($colors-blue, 10);
+  color: color.adjust($colors-blue, $lightness: 10%);
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## Summary
- fix style nesting order in the watch page to avoid `mixed-decls` warning
- replace deprecated `lighten()` with `color.adjust()`
- import the `sass:color` module where needed

## Testing
- `npm run build`